### PR TITLE
Fixing untar file issue

### DIFF
--- a/Scheduler+Agent/client.py
+++ b/Scheduler+Agent/client.py
@@ -75,6 +75,11 @@ class TCPClient ():
         l = f.read(8192)
       f.close()
       self.lctx.debug("Done Sending")
+      time.sleep(1)
+      # TODO: sleep is a temporary fix assuming there is a 500 msec delay on receiver side...ideally I would like to receive a ACK from scheduler after receiving result.tgz, below is the implementation for the same but it is not working and require some investigation
+      # response = sock.recv(8192)
+      # if response == "FILECOMPLETE":
+      #    self.lctx.debug(response)
       sock.shutdown(socket.SHUT_WR)
     except IOError:
       self.lctx.error("Server not responding, perhaps server not running")

--- a/Scheduler+Agent/server.py
+++ b/Scheduler+Agent/server.py
@@ -218,6 +218,9 @@ class serv:
                         serv.lctx.debug(len(l))
                     f.close()
                     serv.lctx.debug("Done receiving results : " + filepath)
+		    # Sample code for sending exec host signal that file receive complete, it can proceed further but code is not working. Check client.py:80 for client side code
+		    # response = "{}".format("FILECOMPLETE")
+                    # self.request.send(response)
                     return
 
                 if cmd == "DAYTONA_STOP_SERVER":


### PR DESCRIPTION
On file transfer after exec host finish sending result.tgz to scheduler, it proceed forward with the normal flow and signal scheduler thread that file transfer is complete which trigger file extraction on scheduler. However as per logs there is a delay on scheduler side (different thread) in receiving file which is causing delay in creating file hence extraction fails.

Inserted sleep for 1 sec on exec host after sending 1 content to wait for 1 sec so that scheduler thread can finish receiving file. As per below stackoverflow thread there is a possibility of 500 msec delay on recv side.

[https://stackoverflow.com/questions/19741196/recv-function-too-slow](https://stackoverflow.com/questions/19741196/recv-function-too-slow)